### PR TITLE
Get XZ Projection to work for geometry and axis drawing.

### DIFF
--- a/Jingyu_demo/display/EveDisplay.cxx
+++ b/Jingyu_demo/display/EveDisplay.cxx
@@ -12,6 +12,7 @@
 #include "TEveProjectionAxes.h"
 #include "TEveScene.h"
 #include "TEveWindow.h"
+#include "TEveBrowser.h"
 #include "TEveBox.h"
 #include "TRandom.h"
 #include <iostream>

--- a/graf3d/eve/inc/TEveProjections.h
+++ b/graf3d/eve/inc/TEveProjections.h
@@ -208,6 +208,9 @@ public:
 
 class TEveXZProjection : public TEveProjection
 {
+private:
+   TEveVector   fProjectedCenter; // projected center of distortion.
+
 public:
    TEveXZProjection();
    virtual ~TEveXZProjection() {}
@@ -216,6 +219,11 @@ public:
    virtual Bool_t Is3D() const { return kFALSE; }
 
    virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+
+   virtual void     SetCenter(TEveVector& v);
+   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+
+   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
 
    ClassDef(TEveXZProjection, 0); // XZ non-linear projection.
 };

--- a/graf3d/eve/src/TEveProjectionManagerEditor.cxx
+++ b/graf3d/eve/src/TEveProjectionManagerEditor.cxx
@@ -50,6 +50,7 @@ TEveProjectionManagerEditor::TEveProjectionManagerEditor(const TGWindow *p,
       f->AddFrame(lab, new TGLayoutHints(kLHintsLeft|kLHintsBottom, 1, 31, 1, 2));
       fType = new TGComboBox(f);
       fType->AddEntry("RPhi", TEveProjection::kPT_RPhi);
+      fType->AddEntry("XZ",   TEveProjection::kPT_XZ);
       fType->AddEntry("RhoZ", TEveProjection::kPT_RhoZ);
       fType->AddEntry("3D",   TEveProjection::kPT_3D);
       TGListBox* lb = fType->GetListBox();

--- a/graf3d/eve/src/TEveProjections.cxx
+++ b/graf3d/eve/src/TEveProjections.cxx
@@ -580,7 +580,6 @@ void TEveRhoZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
       if (fUsePreScale)
          PreScalePoint(y, x);
 
-
       // distort
 
       if (!fDisplaceOrigin) {
@@ -762,6 +761,7 @@ void TEveRPhiProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
          y += fCenter.fY;
       }
    }
+
    z = d;
 }
 
@@ -787,9 +787,8 @@ TEveXZProjection::TEveXZProjection() :
 /// Project point.
 
 void TEveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
-                                      Float_t d, EPProc_e proc)
+                                    Float_t d, EPProc_e proc)
 {
-   
    using namespace TMath;
    
    if (fDisplaceOrigin)
@@ -798,13 +797,14 @@ void TEveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
       y  -= fCenter.fY;
       z  -= fCenter.fZ;
    }
-   
 
-   //projcetion
-   y = z;
-   z = d;
-   
-   if (proc != kPP_Plane)
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      y = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
    {
       Float_t r, phi;
       if (fUsePreScale)
@@ -818,9 +818,8 @@ void TEveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
 
       if (!fDisplaceOrigin)
       {
-         x  -= fCenter.fX;
-         y  -= fCenter.fY;
-         z  -= fCenter.fZ;
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
       }
 
       r   = Sqrt(x*x + y*y);
@@ -838,13 +837,44 @@ void TEveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
 
       if (!fDisplaceOrigin)
       {
-         x += fCenter.fX;
-         y += fCenter.fY;
-         z += fCenter.fZ;
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
       }
    }
-   
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void TEveXZProjection::SetCenter(TEveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fX;
+      fProjectedCenter.fY = fCenter.fZ;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class TEveProjection.
+
+void TEveXZProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(1.0f, 0.0f, 0.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 0.0f, 1.0f);
+}
+
 
 /** \class TEve3DProjection
 \ingroup TEve


### PR DESCRIPTION
As you can see, it was rather complicated :)

1. Geometry is projected in two stages ... first into projection plane (there the polygons / segments are reduced for the projected view) and then they are distorted / scaled. For RPHi this was trivial as it does x->x. y->y, so I had to do something similar to RhoZ where these two stages are separate ... it took me while to remember all this, we did this almost 10 years back :)

2. I needed to implement a virtual method to define coordinate axis directions, this is used buy axis painter.

I'm still confuse how fUsePreScale and fDisplaceOrigin are used in various ProjectPoint implementations, it seems to me they are not consistent.

Give this a try and I'll try to figure out how fUsePreScale and fDisplaceOrigin need to be used.
